### PR TITLE
Add memcached ports to the firewall, udp and tcp

### DIFF
--- a/resources/scripts/rb_init_conf.rb
+++ b/resources/scripts/rb_init_conf.rb
@@ -336,6 +336,10 @@ if !network.nil? #Firewall rules are not needed in cloud environments
   #webui
   system("firewall-cmd --permanent --zone=home --add-port=8001/tcp &>/dev/null")
 
+  #memcached
+  system("firewall-cmd --permanent --zone=home --add-port=11211/tcp &>/dev/null")
+  system("firewall-cmd --permanent --zone=home --add-port=11211/udp &>/dev/null")
+
   # Reload firewalld configuration
   system("firewall-cmd --reload &>/dev/null")
 


### PR DESCRIPTION
* This PR adds memcached firewall rule to allow communication of memcached in the sync network