### PR TITLE
Generate random 128 bit serial for ssl cert

### DIFF
--- a/resources/scripts/rb_create_nginx_certs.rb
+++ b/resources/scripts/rb_create_nginx_certs.rb
@@ -3,13 +3,14 @@
 require 'json'
 require 'openssl'
 require 'base64'
+require 'securerandom'
 
 def create_cert(cn)
 	key = OpenSSL::PKey::RSA.new 4096
 	name = OpenSSL::X509::Name.parse "CN=#{cn}/DC=redborder"
 	cert = OpenSSL::X509::Certificate.new
 	cert.version = 2
-	cert.serial = 0
+	cert.serial = SecureRandom.random_number(2**128)
 	cert.not_before = Time.now
 	cert.not_after = Time.now + (3600 *24 *365 *10)
 	cert.public_key = key.public_key


### PR DESCRIPTION
* Fixes Error code: SEC_ERROR_REUSED_ISSUER_AND_SERIAL in firefox