### PR TITLE
Remove obsolete package rsyslog-logrotate when installing redborder-manager

### DIFF
--- a/packaging/rpm/redborder-manager.spec
+++ b/packaging/rpm/redborder-manager.spec
@@ -7,6 +7,7 @@ BuildArch: noarch
 Summary: Main package for redborder manager
 
 License: AGPL 3.0
+Obsoletes: rsyslog-logrotate
 URL: https://github.com/redBorder/redborder-manager
 Source0: %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
* Using Obosolete option in the specfile allows to uninstall a package