### PR TITLE
Feature/#20511 bring back compile assets script

### DIFF
--- a/resources/bin/rb_compile_assets.sh
+++ b/resources/bin/rb_compile_assets.sh
@@ -1,0 +1,30 @@
+#!/bin/bash 
+
+#######################################################################
+# Copyright (c) 2014 ENEO Tecnología S.L.
+# This file is part of redBorder.
+# redBorder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# redBorder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License License for more details.
+# You should have received a copy of the GNU Affero General Public License License
+# along with redBorder. If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
+source /etc/profile.d/redborder-*
+source /etc/profile.d/rvm.sh
+
+pushd /var/www/rb-rails/ &>/dev/null
+
+if [[ "$GEM_HOME" != *@web ]]; then
+    rvm gemset use web
+fi
+
+
+rake assets:precompile
+chown webui:webui -R /var/www/rb-rails/
+popd &>/dev/null


### PR DESCRIPTION
### Adapt rb_compile_assets script from legacy to NG  

- Updated directory path from `/opt/rb/var/www/rb-rails/` to `/var/www/rb-rails/`.  
- Added RVM gemset check to ensure `web` gemset is used before running `rake assets:precompile`.  
- Changed user/group ownership from `rb-webui:rb-webui` to `webui:webui`. 