### PR TITLE
Feature/#22037 add script to show delayed jobs

### DIFF
--- a/resources/bin/rb_get_delayed_job.sh
+++ b/resources/bin/rb_get_delayed_job.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -
+
+#######################################################################
+# Copyright (c) 2025 ENEO Tecnologia S.L.
+# This file is part of redBorder.
+# redBorder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# redBorder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License License for more details.
+# You should have received a copy of the GNU Affero General Public License License
+# along with redBorder. If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
+if [ ! -d /var/www/rb-rails ]; then
+    echo 'ERROR: rb-rails not found!'
+    exit 1
+fi
+
+source /etc/profile
+
+pushd /var/www/rb-rails &>/dev/nul
+
+rvm gemset use web &>/dev/null
+
+ruby /var/www/rb-rails/script/rb_get_delayed_job.rb $*
+
+exit 0


### PR DESCRIPTION
This script allows querying and filtering Delayed::Job entries in a Rails application. It displays detailed information about running, completed, or failed jobs and supports multiple filters by time or text search.

**Main Features:**

- View only the jobs currently running.

- Use --all or -a to list all jobs, regardless of status.

- Filter jobs:

  - That have been running for at least a certain time (--time-lapsed, -tl).

  - That were executed recently (--executed, -e).

  - By partial name or class (--search, -s).

- Supported time format: s (seconds), m (minutes), h (hours), d (days).

- Displays name, status, priority, key timestamps, and execution duration.



Usage Examples:
```
rb_get_delayed_job -tl 10m       # Jobs running for at least 10 minutes  
rb_get_delayed_job -e 1h         # Jobs executed within the last hour  
rb_get_delayed_job -a            # All jobs  
rb_get_delayed_job -s Invoice    # Search for jobs related to "Invoice"  
```