### PR TITLE
Bugfix/#22854 adding nginx databag on install

### DIFF
--- a/resources/bin/rb_configure_leader.sh
+++ b/resources/bin/rb_configure_leader.sh
@@ -332,9 +332,9 @@ _RBEOF_
 
   ## Generating external virtual ip
   mkdir -p /var/chef/data/data_bag/rBglobal
-  cat > /var/chef/data/data_bag/rBglobal/ipvirtual-external-webui.json <<-_RBEOF_
+  cat > /var/chef/data/data_bag/rBglobal/ipvirtual-external-nginx.json <<-_RBEOF_
 {
-  "id": "ipvirtual-external-webui"
+  "id": "ipvirtual-external-nginx"
 }
 _RBEOF_
 


### PR DESCRIPTION
Databag was being renamed from webui to nginx, but on configure leader, still being created as webui. 